### PR TITLE
Add hero callout container to pricing page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -258,6 +258,23 @@ body.wide .pages{border-radius:18px}
 
 #tab-preview .feature .icon, #page1 .feature .icon, #page2 .feature .icon { background: transparent !important; box-shadow:none !important; }
 #tab-preview .feature, #page1 .feature, #page2 .feature { margin:8px 0 !important; }
+#page2 .hero-callouts {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+  gap:16px;
+  margin:0 0 20px;
+}
+#page2 .hero-callouts:empty {
+  display:none;
+}
+#page2 .hero-callouts .feature {
+  margin:0 !important;
+  break-inside:avoid;
+  page-break-inside:avoid;
+}
+#page2 .hero-callouts .feature.hero {
+  grid-column:1 / -1;
+}
 #page2 #heroAbovePricing { margin:8px 0 12px !important; }
 #page2 #heroAbovePricing .ttl { font-weight:700; }
 

--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@ Includes installation, programming, call-flows & training</textarea></div>
         </section>
         <section class="page" id="page2">
           <div style="padding:24px 28px 32px">
+            <div class="hero-callouts" id="heroCallouts"></div>
             <h3 style="margin:0;font-size:28px">Inclusions & pricing breakdown</h3>
             <table class="table" id="priceTableView"><thead><tr><th style="width:60%">Item</th><th>Qty</th><th>Unit</th><th id="thPriceV">Price (ex GST)</th></tr></thead><tbody></tbody></table>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">

--- a/js/app.js
+++ b/js/app.js
@@ -750,6 +750,7 @@ function initializeApp() {
 
   const featureGrid = doc.getElementById('featureGrid');
   const featurePreview = doc.getElementById('featuresView');
+  const heroFeaturePreview = doc.getElementById('heroCallouts');
   const addFeatureBtn = doc.getElementById('btnAddFeat');
   const iconModal = doc.getElementById('iconModal');
   const iconGallery = doc.getElementById('iconGallery');
@@ -1158,50 +1159,77 @@ function initializeApp() {
   };
 
   const renderFeaturePreview = () => {
-    if (!featurePreview) {
+    if (!featurePreview && !heroFeaturePreview) {
       return;
     }
-    featurePreview.innerHTML = "";
+    const standardFeatures = [];
+    const heroFeatures = [];
     for (const feature of state.features) {
-      const card = doc.createElement('div');
-      card.className = `feature${feature.hero ? " hero" : ""}`;
-
-      const iconWrap = doc.createElement('div');
-      iconWrap.className = "icon";
-      const size = Number(feature.size) || 56;
-      iconWrap.style.width = `${size}px`;
-      iconWrap.style.height = `${size}px`;
-      const img = doc.createElement('img');
-      img.src = feature.img || resolveIcon(feature.icon);
-      iconWrap.appendChild(img);
-      card.appendChild(iconWrap);
-
-      const body = doc.createElement('div');
-      body.style.minWidth = "0";
-      if (feature.t) {
-        const title = doc.createElement('div');
-        title.style.fontWeight = "700";
-        title.style.fontSize = "18px";
-        title.style.marginBottom = "4px";
-        title.textContent = feature.t;
-        body.appendChild(title);
+      if (feature.hero) {
+        heroFeatures.push(feature);
+      } else {
+        standardFeatures.push(feature);
       }
-      if (feature.c) {
-        if (feature.c.includes('\n')) {
-          const list = doc.createElement('ul');
-          list.innerHTML = bulletify(feature.c);
-          body.appendChild(list);
-        } else {
-          const copy = doc.createElement('div');
-          copy.className = "note";
-          copy.style.fontSize = "16px";
-          copy.textContent = feature.c;
-          body.appendChild(copy);
-        }
-      }
-      card.appendChild(body);
-      featurePreview.appendChild(card);
     }
+
+    const renderFeatureCards = (container, items) => {
+      if (!container) {
+        return;
+      }
+      container.innerHTML = "";
+      if (!items.length) {
+        if (container === heroFeaturePreview) {
+          container.style.display = "none";
+        }
+        return;
+      }
+      if (container === heroFeaturePreview) {
+        container.style.display = "";
+      }
+      for (const feature of items) {
+        const card = doc.createElement('div');
+        card.className = `feature${feature.hero ? " hero" : ""}`;
+
+        const iconWrap = doc.createElement('div');
+        iconWrap.className = "icon";
+        const size = Number(feature.size) || 56;
+        iconWrap.style.width = `${size}px`;
+        iconWrap.style.height = `${size}px`;
+        const img = doc.createElement('img');
+        img.src = feature.img || resolveIcon(feature.icon);
+        iconWrap.appendChild(img);
+        card.appendChild(iconWrap);
+
+        const body = doc.createElement('div');
+        body.style.minWidth = "0";
+        if (feature.t) {
+          const title = doc.createElement('div');
+          title.style.fontWeight = "700";
+          title.style.fontSize = "18px";
+          title.style.marginBottom = "4px";
+          title.textContent = feature.t;
+          body.appendChild(title);
+        }
+        if (feature.c) {
+          if (feature.c.includes('\n')) {
+            const list = doc.createElement('ul');
+            list.innerHTML = bulletify(feature.c);
+            body.appendChild(list);
+          } else {
+            const copy = doc.createElement('div');
+            copy.className = "note";
+            copy.style.fontSize = "16px";
+            copy.textContent = feature.c;
+            body.appendChild(copy);
+          }
+        }
+        card.appendChild(body);
+        container.appendChild(card);
+      }
+    };
+
+    renderFeatureCards(featurePreview, standardFeatures);
+    renderFeatureCards(heroFeaturePreview, heroFeatures);
   };
 
   let currentFeatureIndex = -1;


### PR DESCRIPTION
## Summary
- add a hero callout container above the pricing table on page 2 of the preview
- update feature preview rendering to keep standard tiles on page 1 and move hero tiles into the new container
- style the hero callout grid so it aligns with the pricing layout and prints cleanly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d66fc01a2c832abdba804f747fd508