### PR TITLE
Align features preview columns with hero and standard features

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -16,6 +16,18 @@ input[type=text],input[type=number],textarea,select{width:100%;padding:12px;bord
 .page{min-height:1160px;background:#fff}
 .banner-img{width:100%;height:320px;object-fit:cover;display:block}
 .fgrid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.features-preview{display:grid;gap:24px;grid-template-columns:minmax(0,1fr);align-items:start}
+@media (min-width:960px){
+  .features-preview.two-cols{grid-template-columns:repeat(2,minmax(0,1fr));align-items:start}
+}
+.features-column{display:flex;flex-direction:column;gap:16px}
+.features-column .column-header .title{font-size:20px;font-weight:800;color:#0B1220}
+.features-column .column-header .subtitle{font-size:14px;font-weight:600;letter-spacing:.04em;color:#5B6573}
+.feature-list{display:grid;grid-template-columns:1fr;gap:16px}
+.hero-callouts{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px}
+.hero-callouts:empty{display:none}
+.hero-callouts .feature{margin:0 !important;break-inside:avoid;page-break-inside:avoid}
+.hero-callouts .feature.hero{grid-column:span 2}
 .feature{display:flex;gap:12px;border:1px solid var(--line);border-radius:14px;padding:12px;background:#fff;align-items:flex-start}
 .feature.hero{grid-column:1 / span 2;min-height:160px}
 .feature .icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:56px;height:56px}
@@ -258,23 +270,6 @@ body.wide .pages{border-radius:18px}
 
 #tab-preview .feature .icon, #page1 .feature .icon, #page2 .feature .icon { background: transparent !important; box-shadow:none !important; }
 #tab-preview .feature, #page1 .feature, #page2 .feature { margin:8px 0 !important; }
-#page2 .hero-callouts {
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-  gap:16px;
-  margin:0 0 20px;
-}
-#page2 .hero-callouts:empty {
-  display:none;
-}
-#page2 .hero-callouts .feature {
-  margin:0 !important;
-  break-inside:avoid;
-  page-break-inside:avoid;
-}
-#page2 .hero-callouts .feature.hero {
-  grid-column:1 / -1;
-}
 #page2 #heroAbovePricing { margin:8px 0 12px !important; }
 #page2 #heroAbovePricing .ttl { font-weight:700; }
 

--- a/index.html
+++ b/index.html
@@ -177,12 +177,26 @@ Includes installation, programming, call-flows & training</textarea></div>
               </div>
             </div>
             <div style="margin-top:10px"><div style="font-size:28px;font-weight:800" id="pvHero">Cloud voice for modern schools & businesses</div></div>
-            <div class="fgrid" id="featuresView" style="margin-top:12px"></div>
+            <div class="features-preview" id="featuresPreview" style="margin-top:12px">
+              <section class="features-column standard" id="standardFeaturesColumn">
+                <div class="column-header">
+                  <div class="title">Features &amp; benefits</div>
+                  <div class="subtitle">(STANDARD FEATURES)</div>
+                </div>
+                <div class="feature-list" id="featuresView"></div>
+              </section>
+              <section class="features-column hero" id="heroFeaturesColumn">
+                <div class="column-header">
+                  <div class="title">Key features</div>
+                  <div class="subtitle">(HERO FEATURES)</div>
+                </div>
+                <div class="hero-callouts" id="heroCallouts"></div>
+              </section>
+            </div>
           </div>
         </section>
         <section class="page" id="page2">
           <div style="padding:24px 28px 32px">
-            <div class="hero-callouts" id="heroCallouts"></div>
             <h3 style="margin:0;font-size:28px">Inclusions & pricing breakdown</h3>
             <table class="table" id="priceTableView"><thead><tr><th style="width:60%">Item</th><th>Qty</th><th>Unit</th><th id="thPriceV">Price (ex GST)</th></tr></thead><tbody></tbody></table>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">

--- a/js/app.js
+++ b/js/app.js
@@ -689,14 +689,9 @@ function buildEmailHTML() {
 
   if (heroCards.length) {
     out.push('<section class="card hero-cards">');
- codex/update-hero-section-heading-in-buildemailhtml
     out.push('<div class="card-header"><h2>Key features</h2></div>');
     out.push('<div class="card-body hero-grid">');
-
-    out.push('<div class="card-header"><h2>Hero success stories</h2></div>');
-    out.push('<div class="card-body">');
     out.push('<table role="presentation" width="100%" style="width:100%;border-collapse:collapse;">');
- main
     for (const card of heroCards) {
       out.push('<tr>');
       out.push('<td style="padding:0 0 16px;vertical-align:top;">');
@@ -802,6 +797,9 @@ function initializeApp() {
   const termInput = doc.getElementById('term');
 
   const featureGrid = doc.getElementById('featureGrid');
+  const featuresPreviewLayout = doc.getElementById('featuresPreview');
+  const standardFeaturesColumn = doc.getElementById('standardFeaturesColumn');
+  const heroFeaturesColumn = doc.getElementById('heroFeaturesColumn');
   const featurePreview = doc.getElementById('featuresView');
   const heroFeaturePreview = doc.getElementById('heroCallouts');
   const addFeatureBtn = doc.getElementById('btnAddFeat');
@@ -1249,6 +1247,9 @@ function initializeApp() {
     if (!featurePreview && !heroFeaturePreview) {
       return;
     }
+    if (featuresPreviewLayout) {
+      featuresPreviewLayout.classList.remove('two-cols');
+    }
     const standardFeatures = [];
     const heroFeatures = [];
     for (const feature of state.features) {
@@ -1263,14 +1264,19 @@ function initializeApp() {
       if (!container) {
         return;
       }
+      const column = container === featurePreview ? standardFeaturesColumn : container === heroFeaturePreview ? heroFeaturesColumn : null;
       container.innerHTML = "";
       if (!items.length) {
-        if (container === heroFeaturePreview) {
+        if (column) {
+          column.style.display = "none";
+        } else if (container === heroFeaturePreview) {
           container.style.display = "none";
         }
         return;
       }
-      if (container === heroFeaturePreview) {
+      if (column) {
+        column.style.display = "";
+      } else if (container === heroFeaturePreview) {
         container.style.display = "";
       }
       for (const feature of items) {
@@ -1317,6 +1323,14 @@ function initializeApp() {
 
     renderFeatureCards(featurePreview, standardFeatures);
     renderFeatureCards(heroFeaturePreview, heroFeatures);
+    if (featuresPreviewLayout) {
+      if (standardFeatures.length && heroFeatures.length) {
+        featuresPreviewLayout.classList.add('two-cols');
+      } else {
+        featuresPreviewLayout.classList.remove('two-cols');
+      }
+      featuresPreviewLayout.style.display = standardFeatures.length || heroFeatures.length ? "" : "none";
+    }
   };
 
   let currentFeatureIndex = -1;


### PR DESCRIPTION
## Summary
- restructure the preview features area into labelled standard and hero columns
- add styling and rendering logic so standard features stay single-column while hero cards span two columns
- tidy the email export hero section by removing stray debug text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d672b30d00832ab8f7c0fae8ddd41b