### PR TITLE
Update hero layout and remove feature labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@ Includes installation, programming, call-flows & training</textarea></div>
         <section class="page" id="page1">
           <img id="pageBanner" class="banner-img" src="">
           <div style="padding:24px 28px 32px">
+            <div style="font-size:28px;font-weight:800;margin:0 0 10px" id="pvHero">Cloud voice for modern schools & businesses</div>
             <div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">
               <div style="font-weight:800;font-size:20px" id="pvCustomer">Customer</div>
               <span class="badge" id="pvRef">Ref: TIPT-2025-09-14</span>
@@ -179,11 +180,9 @@ Includes installation, programming, call-flows & training</textarea></div>
                 <ul id="pvBenefits" class="note" style="margin:6px 0 0 18px;font-size:16px"></ul>
               </div>
             </div>
-            <div style="margin-top:10px"><div style="font-size:28px;font-weight:800" id="pvHero">Cloud voice for modern schools & businesses</div></div>
             <div class="features-preview" id="featuresPreview" style="margin-top:12px">
               <header class="features-preview-header" id="featuresPreviewHeader">
                 <div class="title">Features &amp; benefits</div>
-                <div class="subtitle">(STANDARD FEATURES)</div>
               </header>
               <div class="feature-list" id="featuresView"></div>
             </div>

--- a/js/app.js
+++ b/js/app.js
@@ -672,9 +672,6 @@ function buildEmailHTML() {
     }
     const { title, copy, image, hero, height } = feature;
     const bodyParts = [];
-    if (hero) {
-      bodyParts.push('<div style="display:inline-block;padding:6px 12px;border-radius:999px;background:#FFF0E5;border:1px solid #FFC8AE;color:#B54E20;font-size:12px;font-weight:700;letter-spacing:0.06em;margin:0 0 12px;text-transform:uppercase;">HERO FEATURE</div>');
-    }
     if (title) {
       bodyParts.push(`<div style="font-size:18px;font-weight:700;margin:0 0 8px;color:#0B1220;">${escapeHTML(title)}</div>`);
     }
@@ -751,20 +748,20 @@ function buildEmailHTML() {
     out.push(`<div style="margin:0 0 24px;"><img src="${escapeHTML(heroImageData)}" alt="Banner" style="width:100%;height:auto;border-radius:20px;display:block;"></div>`);
   }
 
-  if (customer) {
-    out.push(`<div style="margin:0 0 12px;"><span style="display:inline-block;padding:8px 16px;border-radius:999px;background:${escapeHTML(panelColor)};color:${pillTextColor};font-weight:700;letter-spacing:0.03em;">${escapeHTML(customer)}</span></div>`);
-  }
-
-  if (referenceLine) {
-    out.push(`<div style="font-weight:600;font-size:14px;color:#5B6573;margin:0 0 16px;">${escapeHTML(referenceLine)}</div>`);
-  }
-
   if (heroTitle) {
     out.push(`<div style="font-size:30px;font-weight:800;line-height:1.2;margin:0 0 8px;">${escapeHTML(heroTitle)}</div>`);
   }
 
   if (heroSubtitle) {
     out.push(`<div style="font-size:18px;line-height:1.5;color:#5B6573;margin:0 0 24px;">${escapeHTML(heroSubtitle)}</div>`);
+  }
+
+  if (customer) {
+    out.push(`<div style="margin:0 0 12px;"><span style="display:inline-block;padding:8px 16px;border-radius:999px;background:${escapeHTML(panelColor)};color:${pillTextColor};font-weight:700;letter-spacing:0.03em;">${escapeHTML(customer)}</span></div>`);
+  }
+
+  if (referenceLine) {
+    out.push(`<div style="font-weight:600;font-size:14px;color:#5B6573;margin:0 0 16px;">${escapeHTML(referenceLine)}</div>`);
   }
 
   if (hasSummary || hasBenefits) {
@@ -1410,11 +1407,6 @@ function initializeApp() {
 
       if (feature.hero) {
         heroCount += 1;
-        const badge = doc.createElement('span');
-        badge.className = "badge hero-badge";
-        badge.textContent = "HERO FEATURE";
-        badge.style.alignSelf = "flex-start";
-        body.appendChild(badge);
       }
 
       if (titleText) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -506,7 +506,9 @@ test('buildEmailHTML composes full export with escaped content and live data', (
   assert.ok(html.includes('Boost morale'));
   assert.ok(html.includes('Improve security'));
   assert.ok(html.includes('Features &amp; benefits'));
-  assert.ok(html.includes('HERO FEATURE'));
+  assert.ok(!html.includes('HERO FEATURE'));
+  assert.ok(html.indexOf('Modernise your workplace') < html.indexOf('Telstra Enterprise'));
+  assert.ok(!html.includes('(STANDARD FEATURES)'));
   assert.ok(html.includes('Hero Cloud'));
   assert.ok(html.includes('Elastic scale &amp;lt;all year&amp;gt;'));
   assert.ok(html.includes('Fast rollout &lt;guaranteed&gt;'));


### PR DESCRIPTION
## Summary
- move the preview headline above the customer badge and drop the default standard features subtitle
- remove the "HERO FEATURE" pill from preview cards and exported markup while keeping hero cards intact
- ensure the email export renders the headline before customer details and add tests to guard the new layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69fdf6790832a9606b7596fbc0d3f