### PR TITLE
Add searchable icon gallery using PNG pictograms

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,6 +40,11 @@ input[type=text],input[type=number],textarea,select{width:100%;padding:12px;bord
 .controls{display:grid;grid-template-columns:1fr 1fr;gap:10px}.chk{display:flex;gap:10px;align-items:center}
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;padding:20px;z-index:1000}
 .modal .panel{background:#fff;max-width:900px;width:100%;border-radius:16px;border:1px solid var(--line);padding:12px}
+.modal .modal-head{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px}
+.modal .modal-head strong{font-size:18px;flex:1 1 180px}
+.modal .modal-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+#iconSearch{flex:1 1 220px;min-width:180px;padding:10px 12px;border:1px solid var(--line);border-radius:10px;background:#fff;font-size:14px}
+#iconGalleryStatus{margin-top:8px}
 .modal .actions{display:flex;justify-content:flex-end;gap:8px;margin-top:6px}
 .toast{position:fixed;right:16px;bottom:16px;background:#122B5C;color:#fff;padding:10px 12px;border-radius:10px;display:none;z-index:2000}
 #tab-start .card{display:flex;flex-direction:column}

--- a/index.html
+++ b/index.html
@@ -111,10 +111,14 @@ Managed & reliable</textarea></div>
       <div class="fgrid" id="featureGrid"></div>
       <div class="modal" id="iconModal">
         <div class="panel">
-          <div style="display:flex;justify-content:space-between;align-items:center">
+          <div class="modal-head">
             <strong>Select an icon</strong>
-            <div><input id="iconUpload" type="file" accept="image/*" class="btn"></div>
+            <div class="modal-tools">
+              <input id="iconSearch" type="search" placeholder="Search pictograms…" aria-label="Search pictograms">
+              <input id="iconUpload" type="file" accept="image/*" class="btn" title="Upload your own icon">
+            </div>
           </div>
+          <div class="note" id="iconGalleryStatus"></div>
           <div class="gallery" id="iconGallery"></div>
           <div class="actions"><button class="btn" id="closeIcon" type="button">Close</button></div>
         </div>


### PR DESCRIPTION
## Summary
- add a search field and status label to the icon modal so all bundled pictograms are easy to browse
- filter the gallery to PNG-based assets, add keyboard selection, and report how many results match the current search
- restyle the modal header/tools area to accommodate the new search input while keeping upload support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a389f07c832aa8ba7007e8276952