### PR TITLE
Filter icon gallery to PNG pictograms

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1504,7 +1504,7 @@ function initializeApp() {
     }
     if (!iconGalleryBuilt) {
       const entries = Object.entries(iconMap)
-        .filter(([name]) => typeof name === 'string' && !/\.svg$/i.test(name))
+        .filter(([name]) => typeof name === 'string' && /\.png$/i.test(name))
         .sort((a, b) => a[0].localeCompare(b[0], undefined, { sensitivity: 'base' }));
       iconGallery.innerHTML = "";
       iconItems.length = 0;


### PR DESCRIPTION
## Summary
- limit the icon gallery in the feature modal to entries with .png extensions so only pictograms appear

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a6d52b0c832ab0a8d37af20c48cd