### PR TITLE
Adjust preview and editors for proposal studio

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -39,6 +39,19 @@ input[type=text],input[type=number],textarea,select{width:100%;padding:12px;bord
 .item img{width:100%;height:auto;max-height:100%;object-fit:contain}
 .item.selected{outline:2px solid var(--blue)}
 .table{width:100%;border-collapse:collapse;margin-top:8px;font-size:15px}.table th,.table td{border-top:1px solid var(--line);padding:12px;vertical-align:top}.table th{background:#f6f8fb;text-align:left;font-weight:700}
+.line-editor-panel{margin-top:16px;padding:16px;border:1px solid var(--line);border-radius:14px;background:var(--sand20);display:flex;flex-direction:column;gap:14px}
+.line-editor-title{font-weight:700;color:#122B5C;font-size:16px}
+.line-editor-list{display:flex;flex-direction:column;gap:12px}
+.line-editor-actions{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+.line-item-row{display:grid;grid-template-columns:minmax(0,1fr) 90px 110px 150px auto;gap:10px;align-items:center;background:#fff;border:1px solid var(--line);border-radius:12px;padding:12px;box-shadow:0 2px 6px rgba(18,43,92,.06)}
+.line-item-row input{width:100%}
+.line-item-row .btn{justify-content:center}
+@media (max-width:960px){
+  .line-item-row{grid-template-columns:minmax(0,1fr);grid-auto-rows:minmax(40px,auto)}
+  .line-item-row .btn{grid-column:1 / -1;justify-self:start}
+}
+.pricing-assumptions{margin-top:16px}
+.pricing-assumptions textarea{margin-top:6px}
 .kpi{border:2px solid var(--sand20);border-radius:16px;padding:14px;background:#fff}.kpi .big{font-size:28px;font-weight:800}
 .banner{border:1px dashed var(--line);border-radius:14px;padding:8px;background:#fff}canvas{max-width:100%}
 .controls{display:grid;grid-template-columns:1fr 1fr;gap:10px}.chk{display:flex;gap:10px;align-items:center}
@@ -320,7 +333,7 @@ body.wide .pages{border-radius:18px}
 }
 .feature .hero-badge{background:#FFF0E5;border:1px solid #FFC8AE;color:#B54E20;}
 .feature-badge{display:inline-flex;align-items:center;padding:2px 10px;border-radius:999px;background:#EEF2FF;color:#122B5C;font-weight:700;font-size:12px !important;letter-spacing:.06em;text-transform:uppercase;width:max-content;}
-.key-feature-preview{display:flex;flex-direction:column;gap:16px;}
+.key-feature-preview{display:flex;flex-direction:column;gap:16px;margin:24px 0 12px;}
 .key-feature-preview .feature-list{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));}
 .key-feature-preview .feature{display:flex;flex-wrap:wrap;gap:16px;align-items:flex-start;border:1px solid var(--line);border-radius:18px;padding:18px;background:#fff;}
 .key-feature-preview .feature .icon{flex:0 0 auto;}

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
             <div><label>Offset Y</label><input id="bnY" type="range" min="-100" max="100" step="1" value="0"></div>
           </div>
           <label style="margin-top:8px">Logo</label>
-          <select id="bannerLogoMode"><option value="auto" selected>Auto (based on colour)</option><option>Primary (Blue/Coral)</option><option>Primary on Blue (White T)</option><option>Primary on Coral (White T)</option><option>Mono – White</option><option>Mono – Black</option></select>
+          <select id="bannerLogoMode"><option value="auto" selected>Auto (based on colour)</option></select>
           <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">
             <button class="btn" id="btnBannerUse" type="button">Use banner in document</button>
             <button class="btn" id="btnBannerDownload" type="button">Download PNG</button>
@@ -143,9 +143,12 @@ Managed & reliable</textarea></div>
       </div>
       <h4 style="margin:10px 0 8px 0;font-size:16px;color:#122B5C">Edit line items</h4>
       <table class="table" id="priceTable"><thead><tr><th style="width:60%">Item</th><th>Qty</th><th>Unit</th><th id="thPrice">Price (ex GST)</th></tr></thead><tbody></tbody></table>
-      <div id="items" style="margin-top:8px"></div>
-      <div style="display:flex;gap:8px;align-items:center;margin-top:8px"><button class="btn" id="btnAddItem" type="button">Add line item</button><span class="note">Enter amounts ex GST. Toggle GST in Start → Basics.</span></div>
-      <div style="margin-top:12px"><label>Commercial terms & dependencies (one per line)</label><textarea id="assumptionsEdit">Unlimited AU calls cover Local/STD/Mobile
+      <div class="line-editor-panel">
+        <div class="line-editor-title">Line item editor</div>
+        <div class="line-editor-list" id="items"></div>
+        <div class="line-editor-actions"><button class="btn" id="btnAddItem" type="button">Add line item</button><span class="note">Enter amounts ex GST. Toggle GST in Start → Basics.</span></div>
+      </div>
+      <div class="pricing-assumptions"><label>Commercial terms & dependencies (one per line)</label><textarea id="assumptionsEdit">Unlimited AU calls cover Local/STD/Mobile
 Existing onsite PABX/phones replaced with Cisco IP phones
 Includes installation, programming, call-flows & training</textarea></div>
     </div>
@@ -195,14 +198,14 @@ Includes installation, programming, call-flows & training</textarea></div>
         <section class="page" id="page2">
           <div style="padding:24px 28px 32px">
             <h3 style="margin:0;font-size:28px">Inclusions & pricing breakdown</h3>
+            <div class="key-feature-preview" id="keyFeaturesSection" style="display:none">
+              <h3 style="margin:0 0 12px;font-size:26px">Key features</h3>
+              <div class="feature-list" id="keyFeaturesList"></div>
+            </div>
             <table class="table" id="priceTableView"><thead><tr><th style="width:60%">Item</th><th>Qty</th><th>Unit</th><th id="thPriceV">Price (ex GST)</th></tr></thead><tbody></tbody></table>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px">
               <div><div class="note" style="font-weight:800;margin-bottom:6px">Commercial terms & dependencies</div><ul id="assumptions" class="note" style="margin:6px 0 0 18px;font-size:16px"></ul></div>
               <div class="kpi"><div class="note" style="font-size:14px">Monthly investment</div><div class="big" id="pvMonthly">A$716.00 ex GST</div><div class="note" id="pvTerm2" style="font-size:14px">Term: 36 months</div></div>
-            </div>
-            <div class="key-feature-preview" id="keyFeaturesSection" style="margin-top:28px;display:none">
-              <h3 style="margin:0 0 12px;font-size:26px">Key features</h3>
-              <div class="feature-list" id="keyFeaturesList"></div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- move the key features block above the pricing table on page 2 and drop redundant headings/badges in the preview
- restyle the pricing edit tab with a dedicated line item editor panel and dynamically populate all available banner logos
- expand icon gallery search coverage and improve feature icon sizing controls for hero tiles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d757b36f94832ab6bc1a2e0f8170d3