### PR TITLE
Ensure overview columns stay side-by-side in print

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -78,7 +78,8 @@ input[type=text],input[type=number],textarea,select{width:100%;padding:12px;bord
   #page1{break-after:page;}
   .pages{border:none;border-radius:0}
   .page{page-break-after:always}
-  .overview{grid-template-columns:1fr 1fr!important;gap:18px!important}
+  .overview{display:flex!important;flex-direction:row!important;gap:18px!important}
+  .overview .box{flex:1 1 0!important;min-width:0!important}
 }
 /* Fonts for in-app; email export re-inlines them */
 


### PR DESCRIPTION
## Summary
- force the overview cards to use a horizontal flex layout in print so the executive summary and key benefits stay side by side

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d76d13f63c832abe17ac7474f3c96b