### PR TITLE
Display Included for zero-priced line items

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -986,7 +986,14 @@ function initializeApp() {
       const priceValue = Number.isFinite(Number(item.price)) ? Number(item.price) : 0;
       const baseTotal = qtyValue > 0 ? priceValue * qtyValue : priceValue;
       const displayTotal = state.pricing.gst === "inc" ? baseTotal * 1.1 : baseTotal;
-      const priceText = baseTotal > 0 ? toCurrency(displayTotal) : (priceValue > 0 ? toCurrency(displayTotal) : '');
+      let priceText = '';
+      if (baseTotal > 0) {
+        priceText = toCurrency(displayTotal);
+      } else if (priceValue > 0) {
+        priceText = toCurrency(displayTotal);
+      } else {
+        priceText = 'Included';
+      }
 
       return `<tr><td>${label || '&nbsp;'}</td><td>${qtyText || '&nbsp;'}</td><td>${unit || '&nbsp;'}</td><td>${priceText ? esc(priceText) : '&nbsp;'}</td></tr>`;
     });


### PR DESCRIPTION
## Summary
- show "Included" in pricing tables when a line item totals A$0 so zero-cost inclusions are clearly labeled

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d76d7f3b7c832abbed2fc4f3d2ed44