### PR TITLE
Fix banner logo loading when served from file origin

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1378,6 +1378,19 @@ function initializeApp() {
     return chain;
   };
 
+  const shouldUseAnonymousCrossOrigin = (src) => {
+    if (!src || typeof src !== 'string') {
+      return false;
+    }
+    if (typeof window === 'undefined' || typeof location === 'undefined') {
+      return false;
+    }
+    if (location.protocol === 'file:') {
+      return false;
+    }
+    return needsSafeImagePrefetch(src);
+  };
+
   const ensureSafeImageSource = (src) => {
     if (!src || typeof src !== 'string') {
       return src;
@@ -1560,7 +1573,6 @@ function initializeApp() {
     if (hasRenderableLogo) {
       const logoImage = new Image();
       logoImage.decoding = 'async';
-      logoImage.crossOrigin = 'anonymous';
       logoImage.onload = () => {
         if (!logoImage.naturalWidth || !logoImage.naturalHeight) {
           scheduleBannerSync();
@@ -1595,6 +1607,11 @@ function initializeApp() {
         const finalSrc = (typeof source === 'string' && source) ? source : logoSrc;
         if (logoImage.src === finalSrc) {
           return;
+        }
+        if (shouldUseAnonymousCrossOrigin(finalSrc)) {
+          logoImage.crossOrigin = 'anonymous';
+        } else {
+          logoImage.crossOrigin = null;
         }
         try {
           logoImage.src = finalSrc;


### PR DESCRIPTION
## Summary
- add a helper that skips cross-origin requests when the banner logo is loaded from the local file origin
- reapply the crossOrigin flag only for remote images so logos render in the banner canvas and preview

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77cc8bf14832a99f4a03fbe0d8287