### PR TITLE
Add static sub headline element to preview hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@ Includes installation, programming, call-flows & training</textarea></div>
           <img id="pageBanner" class="banner-img" data-export="banner-image" src="">
           <div style="padding:24px 28px 32px">
             <div style="font-size:28px;font-weight:800;margin:0 0 10px" id="pvHero" data-export="headline-main">Cloud voice for modern schools & businesses</div>
+            <div style="font-size:18px;color:#5B6573;margin:6px 0 18px" id="pvSub" data-export="headline-sub"></div>
             <div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">
               <div style="font-weight:800;font-size:20px" id="pvCustomer" data-export="customer">Customer</div>
               <span class="badge" id="pvRef" data-export="ref">Ref: TIPT-2025-09-14</span>


### PR DESCRIPTION
## Summary
- ensure the preview page renders a sub headline element directly beneath the main headline so the secondary text appears in exports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d787b132a8832aa8018e985c8e55d9