### PR TITLE
Fix email export button by loading email builder script

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@ Includes installation, programming, call-flows & training</textarea></div>
 
 
   <script defer src="js/assets.js"></script>
+  <script defer src="js/emailExport.js"></script>
   <script defer src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the email export module in the browser so the export button can find the builder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d04dc848832a94968a5c8f281ffb