### PR TITLE
Guard email export module for browsers

### DIFF
--- a/js/emailExport.js
+++ b/js/emailExport.js
@@ -658,16 +658,18 @@ async function buildEmailExportHTML(proposal) {
   };
 }
 
-module.exports = {
-  buildEmailExportHTML,
-  // exporting helpers for potential testing
-  __private: {
-    sanitizeHTML,
-    renderFeatureCard,
-    renderKeyBenefits,
-    inlineAllRasterImages,
-  },
-};
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    buildEmailExportHTML,
+    // exporting helpers for potential testing
+    __private: {
+      sanitizeHTML,
+      renderFeatureCard,
+      renderKeyBenefits,
+      inlineAllRasterImages,
+    },
+  };
+}
 
 if (typeof window !== 'undefined') {
   window.PropBuilderEmailExport = window.PropBuilderEmailExport || {};


### PR DESCRIPTION
## Summary
- wrap the CommonJS export in `js/emailExport.js` so it only executes when `module.exports` is available

## Testing
- npm test
- Manual: reloaded the app and confirmed “Download Email HTML” triggers a download without console errors

------
https://chatgpt.com/codex/tasks/task_e_68d7d32c4fc8832a8949c9df6691a0b3