### PR TITLE
Add clipboard support for email export

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@ Includes installation, programming, call-flows & training</textarea></div>
         
         
         <button class="btn" id="btnEmail" type="button">Download Email HTML</button>
+        <button class="btn" id="btnEmailCopy" type="button">Copy Email HTML</button>
         
       </div>
     </div></div>


### PR DESCRIPTION
## Summary
- add a Copy Email HTML control beside the existing download button in the export toolbar
- implement a helper that builds the email HTML and writes it to the clipboard with toast feedback
- wire the new control into initialization without altering the existing download flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d901257df4832ab3bd2bf54c4213c5