### PR TITLE
Remove unused email controls from footer actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,11 +213,6 @@ Includes installation, programming, call-flows & training</textarea></div>
       </div>
       <div class="no-print" style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">
         <button class="btn primary" onclick="window.print()" type="button">Print / Save PROPOSAL PDF</button>
-        
-        
-        <button class="btn" id="btnEmail" type="button">Download Email HTML</button>
-        <button class="btn" id="btnEmailCopy" type="button">Copy Email HTML</button>
-        
       </div>
     </div></div>
   </section>


### PR DESCRIPTION
## Summary
- remove the email HTML download and copy buttons from the footer action bar
- leave the flex layout intact with the remaining print button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7c35287c832a849db56f7266587e