### PR TITLE
Render background feature images with <img> tags

### DIFF
--- a/js/emailExport.js
+++ b/js/emailExport.js
@@ -448,22 +448,30 @@ async function renderFeatureCard(feature, brand, warnings) {
     if ((image.kind === 'css-bg' || image.background === true) && (image.css || image.src)) {
       const width = clampWidth(image.width ?? DEFAULT_IMAGE_WIDTH);
       const height = Math.max(32, Math.round(image.height ?? DEFAULT_IMAGE_HEIGHT));
-      const styleParts = [
-        `width:${width}px`,
-        `height:${height}px`,
-        'background-repeat:no-repeat',
-        'background-size:cover',
-        'background-position:center',
-        'border-radius:12px'
-      ];
-      if (image.src) {
-        styleParts.push(`background-image:url('${esc(image.src)}')`);
+      let imgSrc = image.src || '';
+      if (!imgSrc && image.css) {
+        const match = image.css.match(/background-image\s*:\s*url\((['"]?)([^'")]+)\1\)/i);
+        if (match && match[2]) {
+          imgSrc = match[2];
+        }
       }
+      const altText = image.alt || feature.title || 'Feature image';
+      const styleParts = [
+        'display:block',
+        `width:${width}px`,
+        'max-width:100%',
+        `height:${height}px`,
+        'object-fit:cover',
+        'border:0',
+        'outline:none',
+        'text-decoration:none',
+        'border-radius:12px',
+      ];
       if (image.css) {
         styleParts.push(image.css.trim().replace(/;+$/g, ''));
       }
       const styleAttr = `${styleParts.join('; ')};`;
-      rows.push(`<tr><td style="padding-bottom:12px;"><div style="${styleAttr}"></div></td></tr>`);
+      rows.push(`<tr><td style="padding-bottom:12px;"><img src="${esc(imgSrc)}" alt="${esc(altText)}" width="${width}" height="${height}" style="${styleAttr}"></td></tr>`);
     } else if (image.src) {
       const width = clampWidth(image.width ?? DEFAULT_IMAGE_WIDTH);
       const altText = image.alt || feature.title || 'Feature image';

--- a/test/emailExport.test.js
+++ b/test/emailExport.test.js
@@ -2,7 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 
 const {
-  __private: { inlineAllRasterImages, inlineBackgroundImage },
+  __private: { inlineAllRasterImages, inlineBackgroundImage, renderFeatureCard },
 } = require('../js/emailExport.js');
 
 const createStyle = () => ({
@@ -203,4 +203,27 @@ test('inlineAllRasterImages keeps HTTPS and uploads canvases', async () => {
       global.getComputedStyle = originalGetComputedStyle;
     }
   }
+});
+
+test('renderFeatureCard uses <img> for background images', async () => {
+  const feature = {
+    title: 'Background Feature',
+    image: {
+      background: true,
+      src: 'https://cdn.example.com/background.png',
+      width: 400,
+      height: 220,
+      css: 'border-radius:20px; box-shadow:0 0 10px rgba(0,0,0,0.2);',
+      alt: 'Background graphic',
+    },
+  };
+
+  const html = await renderFeatureCard(feature, null, []);
+
+  assert.ok(html.includes('<img'));
+  assert.ok(html.includes('src="https://cdn.example.com/background.png"'));
+  assert.ok(html.includes('height="220"'));
+  assert.ok(html.includes('object-fit:cover'));
+  assert.ok(html.includes('box-shadow:0 0 10px rgba(0,0,0,0.2)'));
+  assert.ok(!html.includes('background-image'));
 });


### PR DESCRIPTION
## Summary
- update feature card export to render CSS background images with inline <img> elements and preserve styling
- add unit test ensuring background images export as <img>

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfcbf5dd00832a91315692024474c8