### PR TITLE
Add EML export pipeline for preview download

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ Includes installation, programming, call-flows & training</textarea></div>
 
   <section id="tab-preview">
     <div class="card"><div class="hd"><h3 class="no-print">Preview / Export</h3></div><div class="bd">
-      <div class="pages">
+      <div class="pages" id="preview-export">
         <section class="page" id="page1">
           <img id="pageBanner" class="banner-img" data-export="banner-image" src="">
           <div style="padding:24px 28px 32px">


### PR DESCRIPTION
## Summary
- convert the preview/export panel into a #preview-export container for serialization
- add an exportEmailEML flow that builds multipart/related .eml files with inline styles and CID image attachments
- extend the email exporter with quoted-printable encoding helpers and unit tests for the MIME composer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e085eb5554832a9acab122e2a5ba40