### PR TITLE
Inline HTTPS pictogram icons when exporting email

### DIFF
--- a/js/emailExport.js
+++ b/js/emailExport.js
@@ -438,16 +438,14 @@ async function inlineAllRasterImages(root, warnings, options = {}) {
     const currentSrc = image.currentSrc || image.src;
     if (currentSrc && !/^data:/i.test(currentSrc)) {
       const absolute = toAbsoluteHttpsUrl(currentSrc, baseHref);
-      const isHttps = absolute && /^https:/i.test(absolute);
-      if (isHttps) {
+      if (absolute && image.src !== absolute) {
         image.src = absolute;
-      } else {
-        const inlineResult = await imgElementToDataURI(image, warnings);
-        if (inlineResult?.dataUri) {
-          image.src = inlineResult.dataUri;
-        } else if (absolute) {
-          image.src = absolute;
-        }
+      }
+      const inlineResult = await imgElementToDataURI(image, warnings);
+      if (inlineResult?.dataUri) {
+        image.src = inlineResult.dataUri;
+      } else if (absolute) {
+        image.src = absolute;
       }
     }
     ensureImageAttributes(image);


### PR DESCRIPTION
## Summary
- attempt to inline raster images as data URIs before falling back to HTTPS URLs
- add coverage that verifies HTTPS pictogram icons become embedded data URIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0cd3225e8832abbcea4f2a10bf190