### PR TITLE
Add HTML and EML email export options

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,8 @@ Includes installation, programming, call-flows & training</textarea></div>
         </section>
       </div>
       <div class="no-print" style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">
-        <button class="btn" id="btnExportEmail" type="button">Export Email HTML</button>
+        <button class="btn" id="btnExportEmail" type="button">Download Email (.HTML)</button>
+        <button class="btn" id="btnExportEmailEml" type="button">Download Email (.EML)</button>
         <button class="btn primary" onclick="window.print()" type="button">Print / Save PROPOSAL PDF</button>
       </div>
     </div></div>


### PR DESCRIPTION
## Summary
- add separate download buttons for HTML and EML email exports in the preview screen
- expose email export helpers and override hooks to support both export flows
- expand automated tests to cover the new export download behaviours

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e131d819f8832a9135ce400a89c260