### PR TITLE
Rebuild email export layout for enterprise-friendly markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It preserves your styling, branding, fonts (embedded if provided), and adds the 
 
 ## Highlights
 - Tabs: Banner, Executive Summary, Key Benefits, Features, Pricing, Preview/Export.
-- **Email export HTML** now clones the Preview layout so the downloaded markup is pixel-aligned, including the **Ref** field, shaded **price card**, and **Commercial terms & dependencies** (one per line).
+- **Email export HTML** now renders a dedicated enterprise layout that mirrors the Preview styling while using bulletproof table markup, so the downloaded markup keeps the **Ref** badge, summary cards, pricing grid, and inline imagery across desktop email clients.
 - Images in the exported HTML are inlined as data URIs so they continue to render when the markup is pasted directly into email clients.
 - **Print (A4)** uses page logic suitable for two pages: page 1 visual sections, page 2 benefits & pricing (controlled by CSS page breaks).
 - **Features page fix**: no overlapping controls; grid layout; icons keep aspect ratio; sliders resize live; HERO images can scale larger than standard.

--- a/js/emailExport.js
+++ b/js/emailExport.js
@@ -537,17 +537,6 @@ function textToHTML(text) {
   return esc(text).replace(/\r\n|\n|\r/g, '<br>');
 }
 
-function spacerRow(height = 16) {
-  const safeHeight = Math.max(0, Math.round(height));
-  return `<tr><td style="height:${safeHeight}px; line-height:${safeHeight}px; font-size:0;">&nbsp;</td></tr>`;
-}
-
-function sectionHeading(text, brand) {
-  const color = brand?.colorHeading || '#222222';
-  const fontFamily = brand?.fontFamily || FALLBACK_FONT_FAMILY;
-  return `<tr><td style="padding:0 40px; font-family:${esc(fontFamily)}; font-size:22px; line-height:1.4; color:${esc(color)}; font-weight:600;">${esc(text)}</td></tr>`;
-}
-
 async function renderFeatureCard(feature, brand, warnings) {
   const fontFamily = brand?.fontFamily || FALLBACK_FONT_FAMILY;
   const bodyColor = brand?.colorText || '#333333';
@@ -604,7 +593,7 @@ async function renderFeatureCard(feature, brand, warnings) {
     </td></tr>`);
   }
   const content = rows.join('');
-  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border:1px solid rgba(0,0,0,0.08); border-radius:16px; padding:0;">
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="feature" style="width:100%; border:1px solid rgba(0,0,0,0.08); border-radius:16px; padding:0; background-color:#FFFFFF;">
   <tr>
     <td style="padding:20px;">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
@@ -654,12 +643,6 @@ function renderKeyBenefits(benefits, brand) {
   </table>`;
 }
 
-function wrapInSection(content) {
-  return `<tr><td style="padding:0 40px;">
-    ${content}
-  </td></tr>`;
-}
-
 function normalizeBrand(brand) {
   const fallback = {
     fontFamily: FALLBACK_FONT_FAMILY,
@@ -680,20 +663,49 @@ function normalizeBrand(brand) {
   };
 }
 
-async function buildFeatureSection(features, heading, brand, warnings) {
+async function buildFeatureSection(features, heading, brand, warnings, options = {}) {
   if (!features.length) {
     return '';
   }
+  const columns = Math.max(1, Math.min(3, Number.isFinite(options.columns) ? Math.round(options.columns) : 2));
   const cards = [];
   for (const feature of features) {
     const card = await renderFeatureCard(feature, brand, warnings);
-    cards.push(`<tr><td style="padding-bottom:16px;">${card}</td></tr>`);
+    cards.push(card);
   }
-  const cardsTable = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
-    ${cards.join('\n')}
+  const fontFamily = brand?.fontFamily || FALLBACK_FONT_FAMILY;
+  const headingColor = brand?.colorHeading || '#0B1220';
+  const sectionId = options.sectionId || 'features';
+  const rows = [];
+  for (let index = 0; index < cards.length; index += columns) {
+    const cells = [];
+    for (let column = 0; column < columns; column += 1) {
+      const card = cards[index + column];
+      const isLastColumn = column === columns - 1;
+      const isOnlyColumn = columns === 1;
+      const paddingLeft = column === 0 ? 0 : 12;
+      const paddingRight = isLastColumn ? 0 : 12;
+      const padding = isOnlyColumn ? '0 0 24px 0' : `0 ${paddingRight}px 24px ${paddingLeft}px`;
+      if (card) {
+        cells.push(`<td valign="top" style="width:${Math.floor(100 / columns)}%; padding:${padding};">${card}</td>`);
+      } else {
+        cells.push(`<td style="width:${Math.floor(100 / columns)}%; padding:${padding};">&nbsp;</td>`);
+      }
+    }
+    rows.push(`<tr>${cells.join('')}</tr>`);
+  }
+  const cardsTable = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-grid="${esc(sectionId)}" style="width:100%; border-spacing:0;">${rows.join('\n')}</table>`;
+  const headingHtml = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+    <tr>
+      <td style="font-family:${esc(fontFamily)}; font-size:22px; font-weight:700; color:${esc(headingColor)};">${esc(heading)}</td>
+    </tr>
   </table>`;
-  const headingHtml = sectionHeading(heading, brand);
-  return [headingHtml, spacerRow(12), wrapInSection(cardsTable)].join('\n');
+  return `<tr data-email-section="${esc(sectionId)}"><td style="padding:0 32px 32px 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+      <tr><td>${headingHtml}</td></tr>
+      <tr><td style="padding-top:16px;">${cardsTable}</td></tr>
+    </table>
+  </td></tr>`;
 }
 
 async function renderBanner(banner) {
@@ -738,14 +750,13 @@ function buildHeaderSection(proposal, brand) {
   const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
   const headingColor = brand.colorHeading || '#0B1220';
   const bodyColor = brand.colorText || '#333333';
+  const eyebrow = brand.colorMuted || '#6B6F76';
 
   const headlineParts = [];
   if (proposal.customer) {
     headlineParts.push(esc(proposal.customer));
   }
-  if (proposal.ref) {
-    headlineParts.push(`Ref ${esc(proposal.ref)}`);
-  }
+  // reference displayed as badge below; omit from headlineParts to avoid duplication
 
   const headerLine = headlineParts.length
     ? `<tr><td style="font-family:${esc(fontFamily)}; font-size:18px; line-height:1.45; font-weight:600; color:${esc(bodyColor)};">${headlineParts.join(' • ')}</td></tr>`
@@ -760,13 +771,19 @@ function buildHeaderSection(proposal, brand) {
     ? `<tr><td style="padding-top:${subPaddingTop}px; font-family:${esc(fontFamily)}; font-size:18px; line-height:1.45; color:${esc(bodyColor)};">${esc(proposal.headlineSub)}</td></tr>`
     : '';
 
-  const rows = [headerLine, mainHeadline, subheadline].filter(Boolean).join('\n');
+  const badge = proposal.ref
+    ? `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="display:inline-block; border-radius:999px; background-color:rgba(17, 32, 65, 0.08);"><tr><td style="padding:6px 14px; font-family:${esc(fontFamily)}; font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:${esc(eyebrow)};">Ref: ${esc(proposal.ref)}</td></tr></table>`
+    : '';
+
+  const badgeRow = badge ? `<tr><td style="padding-top:14px;">${badge}</td></tr>` : '';
+
+  const rows = [headerLine, mainHeadline, subheadline, badgeRow].filter(Boolean).join('\n');
   if (!rows) {
     return '';
   }
 
-  return `<tr><td style="padding:32px 40px 28px 40px;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
+  return `<tr data-email-section="hero"><td style="padding:32px 32px 28px 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
       ${rows}
     </table>
   </td></tr>`;
@@ -778,8 +795,22 @@ function renderExecutiveSummary(summary, brand) {
   }
   const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
   const bodyColor = brand.colorText || '#333333';
-  const sanitized = sanitizeHTML(summary);
-  return `${sectionHeading('Executive Summary', brand)}\n${spacerRow(12)}\n<tr><td style="padding:0 40px; font-family:${esc(fontFamily)}; font-size:16px; line-height:1.55; color:${esc(bodyColor)};">${sanitized}</td></tr>`;
+  const eyebrow = brand.colorMuted || '#6B6F76';
+  const sanitized = textToHTML(summary);
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="executive-summary" style="width:100%; border:1px solid rgba(11,18,32,0.08); border-radius:16px; background-color:#FFFFFF;">
+    <tr>
+      <td style="padding:24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+          <tr>
+            <td style="font-family:${esc(fontFamily)}; font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:${esc(eyebrow)};">Executive summary</td>
+          </tr>
+          <tr>
+            <td style="padding-top:12px; font-family:${esc(fontFamily)}; font-size:16px; line-height:1.6; color:${esc(bodyColor)};">${sanitized}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>`;
 }
 
 function renderKeyBenefitsSection(benefits, brand) {
@@ -787,7 +818,43 @@ function renderKeyBenefitsSection(benefits, brand) {
   if (!content) {
     return '';
   }
-  return `${sectionHeading('Key Benefits', brand)}\n${spacerRow(12)}\n${wrapInSection(content)}`;
+  const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
+  const eyebrow = brand.colorMuted || '#6B6F76';
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="key-benefits" style="width:100%; border:1px solid rgba(11,18,32,0.08); border-radius:16px; background-color:#FFFFFF;">
+    <tr>
+      <td style="padding:24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+          <tr>
+            <td style="font-family:${esc(fontFamily)}; font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:${esc(eyebrow)};">Key Benefits</td>
+          </tr>
+          <tr>
+            <td style="padding-top:12px;">${content}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>`;
+}
+
+function renderOverviewSection(proposal, brand) {
+  const summaryCard = renderExecutiveSummary(proposal.executiveSummary, brand);
+  const benefitsCard = renderKeyBenefitsSection(proposal.keyBenefits, brand);
+  const cards = [summaryCard, benefitsCard].filter(Boolean);
+  if (!cards.length) {
+    return '';
+  }
+  if (cards.length === 1) {
+    return `<tr data-email-section="overview"><td style="padding:0 32px 32px 32px;">${cards[0]}</td></tr>`;
+  }
+  const [firstCard, secondCard] = cards;
+  return `<tr data-email-section="overview"><td style="padding:0 32px 32px 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+      <tr>
+        <td valign="top" style="padding:0 12px 0 0; width:50%;">${firstCard}</td>
+        <td valign="top" style="padding:0 0 0 12px; width:50%;">${secondCard}</td>
+      </tr>
+    </table>
+  </td></tr>`;
 }
 
 function renderPricingTable(html, brand) {
@@ -795,7 +862,24 @@ function renderPricingTable(html, brand) {
     return '';
   }
   const sanitized = sanitizeHTML(html);
-  return `${sectionHeading('Inclusions & pricing breakdown', brand)}\n${spacerRow(12)}\n<tr><td style="padding:0 40px;">${sanitized}</td></tr>`;
+  const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
+  const eyebrow = brand.colorMuted || '#6B6F76';
+  return `<tr data-email-section="pricing"><td style="padding:0 32px 32px 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="pricing-breakdown" style="width:100%; border:1px solid rgba(11,18,32,0.08); border-radius:16px; background-color:#FFFFFF;">
+      <tr>
+        <td style="padding:24px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+            <tr>
+              <td style="font-family:${esc(fontFamily)}; font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:${esc(eyebrow)};">Inclusions &amp; pricing breakdown</td>
+            </tr>
+            <tr>
+              <td style="padding-top:16px;">${sanitized}</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td></tr>`;
 }
 
 function renderPriceCard(priceCard, brand) {
@@ -805,15 +889,17 @@ function renderPriceCard(priceCard, brand) {
   const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
   const shade = priceCard.shadedBgColor || brand.priceCardShade || '#F3F4F9';
   const sanitized = sanitizeHTML(priceCard.html);
-  return `${sectionHeading('Price card', brand)}\n${spacerRow(12)}\n<tr><td style="padding:0 40px;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-radius:16px; background-color:${esc(shade)};">
-      <tr>
-        <td style="padding:24px; font-family:${esc(fontFamily)}; font-size:16px; line-height:1.55; color:${esc(brand.colorText || '#333333')};">
-          ${sanitized}
-        </td>
-      </tr>
-    </table>
-  </td></tr>`;
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="price-card" style="width:100%; border:1px solid rgba(11,18,32,0.08); border-radius:16px; background-color:#FFFFFF;">
+    <tr>
+      <td style="padding:24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0; background-color:${esc(shade)}; border-radius:12px;">
+          <tr>
+            <td style="padding:24px; font-family:${esc(fontFamily)}; font-size:16px; line-height:1.55; color:${esc(brand.colorText || '#333333')};">${sanitized}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>`;
 }
 
 function normalizeDataSources(sources) {
@@ -873,6 +959,7 @@ function renderDataSourcesSection(sources, brand) {
 
   const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
   const bodyColor = brand.colorText || '#333333';
+  const eyebrow = brand.colorMuted || '#6B6F76';
   const rows = items
     .map((item) => `<tr>
         <td style="width:18px; font-family:${esc(fontFamily)}; font-size:16px; line-height:1.4; color:${esc(bodyColor)};">•</td>
@@ -884,11 +971,24 @@ function renderDataSourcesSection(sources, brand) {
     return '';
   }
 
-  const table = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
+  const table = `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
     ${rows}
   </table>`;
 
-  return `${sectionHeading('Data sources', brand)}\n${spacerRow(12)}\n${wrapInSection(table)}`;
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="data-sources" style="width:100%; border:1px solid rgba(11,18,32,0.08); border-radius:16px; background-color:#FFFFFF;">
+    <tr>
+      <td style="padding:24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+          <tr>
+            <td style="font-family:${esc(fontFamily)}; font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:${esc(eyebrow)};">Data sources</td>
+          </tr>
+          <tr>
+            <td style="padding-top:12px;">${table}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>`;
 }
 
 function renderCommercialTermsSection(terms, brand) {
@@ -896,24 +996,54 @@ function renderCommercialTermsSection(terms, brand) {
   if (!content) {
     return '';
   }
-  return `${sectionHeading('Commercial Terms & Dependencies', brand)}\n${spacerRow(12)}\n${wrapInSection(content)}`;
+  const fontFamily = brand.fontFamily || FALLBACK_FONT_FAMILY;
+  const eyebrow = brand.colorMuted || '#6B6F76';
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" data-email-card="commercial-terms" style="width:100%; border:1px solid rgba(11,18,32,0.08); border-radius:16px; background-color:#FFFFFF;">
+    <tr>
+      <td style="padding:24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+          <tr>
+            <td style="font-family:${esc(fontFamily)}; font-size:12px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:${esc(eyebrow)};">Commercial terms &amp; dependencies</td>
+          </tr>
+          <tr>
+            <td style="padding-top:12px;">${content}</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>`;
 }
 
-function buildHeroSpacer(brand) {
-  const color = brand?.colorMuted || '#E0E0E0';
-  return `<tr><td style="padding:0 40px;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-top:1px solid ${esc(color)};">
-      <tr><td style="font-size:0; line-height:0; height:12px;">&nbsp;</td></tr>
+function renderInvestmentSection(priceCard, commercialTerms, brand) {
+  const priceCardHtml = renderPriceCard(priceCard, brand);
+  const termsHtml = renderCommercialTermsSection(commercialTerms, brand);
+  const blocks = [priceCardHtml, termsHtml].filter(Boolean);
+  if (!blocks.length) {
+    return '';
+  }
+  if (blocks.length === 1) {
+    return `<tr data-email-section="investment"><td style="padding:0 32px 32px 32px;">${blocks[0]}</td></tr>`;
+  }
+  const [firstBlock, secondBlock] = blocks;
+  return `<tr data-email-section="investment"><td style="padding:0 32px 32px 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-spacing:0;">
+      <tr>
+        <td valign="top" style="padding:0 12px 0 0; width:50%;">${firstBlock}</td>
+        <td valign="top" style="padding:0 0 0 12px; width:50%;">${secondBlock}</td>
+      </tr>
     </table>
   </td></tr>`;
 }
 
-function buildOuterWrapper(content) {
-  return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="width:100%; background-color:#FFFFFF;">
+function buildOuterWrapper(content, brand) {
+  const background = EMAIL_BODY_BACKGROUND;
+  const borderColor = 'rgba(11,18,32,0.08)';
+  const surfaceRadius = 28;
+  return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="width:100%; background-color:${esc(background)};">
       <tr>
-        <td align="center" style="padding:0;">
-          <!--[if mso]><table width="${DEFAULT_EMAIL_WIDTH}" align="center"><tr><td><![endif]-->
-          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${DEFAULT_EMAIL_WIDTH}" style="width:${DEFAULT_EMAIL_WIDTH}px; max-width:100%;">
+        <td align="center" style="padding:32px 16px;">
+          <!--[if mso]><table width="${DEFAULT_EMAIL_WIDTH}" align="center" cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${DEFAULT_EMAIL_WIDTH}" data-email-surface="card" style="width:${DEFAULT_EMAIL_WIDTH}px; max-width:100%; background-color:#FFFFFF; border:1px solid ${borderColor}; border-radius:${surfaceRadius}px; overflow:hidden;">
             ${content}
           </table>
           <!--[if mso]></td></tr></table><![endif]-->
@@ -951,66 +1081,46 @@ async function buildLegacyEmailExportHTML(proposal, warnings) {
   const headerSection = buildHeaderSection(proposal, brand);
   if (headerSection) {
     contentParts.push(headerSection);
-    contentParts.push(spacerRow(20));
   }
 
-  const executiveSummaryHtml = renderExecutiveSummary(proposal.executiveSummary, brand);
-  if (executiveSummaryHtml) {
-    contentParts.push(executiveSummaryHtml);
-    contentParts.push(spacerRow(24));
-  }
-
-  const keyBenefitsHtml = renderKeyBenefitsSection(proposal.keyBenefits, brand);
-  if (keyBenefitsHtml) {
-    contentParts.push(keyBenefitsHtml);
-    contentParts.push(spacerRow(24));
+  const overviewSection = renderOverviewSection(proposal, brand);
+  if (overviewSection) {
+    contentParts.push(overviewSection);
   }
 
   const { standard: standardFeatures, hero: heroFeatures } = splitFeatures(proposal.features);
 
   if (standardFeatures.length) {
-    const featureSection = await buildFeatureSection(standardFeatures, 'Features & benefits', brand, warnings);
+    const featureSection = await buildFeatureSection(standardFeatures, 'Features & benefits', brand, warnings, { columns: 2, sectionId: 'features' });
     if (featureSection) {
       contentParts.push(featureSection);
-      contentParts.push(spacerRow(24));
     }
   }
 
   if (heroFeatures.length) {
-    contentParts.push(buildHeroSpacer(brand));
-    contentParts.push(spacerRow(16));
-    const heroSection = await buildFeatureSection(heroFeatures, 'Key Features Included', brand, warnings);
+    const heroSection = await buildFeatureSection(heroFeatures, 'Key features included', brand, warnings, { columns: 1, sectionId: 'hero-features' });
     if (heroSection) {
       contentParts.push(heroSection);
-      contentParts.push(spacerRow(24));
     }
   }
 
   const pricingTableHtml = renderPricingTable(proposal.pricingTableHTML, brand);
   if (pricingTableHtml) {
     contentParts.push(pricingTableHtml);
-    contentParts.push(spacerRow(24));
   }
 
-  const priceCardHtml = renderPriceCard(proposal.priceCard, brand);
+  const investmentSection = renderInvestmentSection(proposal.priceCard, proposal.commercialTerms, brand);
+  if (investmentSection) {
+    contentParts.push(investmentSection);
+  }
+
   const dataSourcesHtml = renderDataSourcesSection(proposal.dataSources, brand);
-
-  if (priceCardHtml) {
-    contentParts.push(priceCardHtml);
-    if (dataSourcesHtml) {
-      contentParts.push(spacerRow(24));
-    }
-  }
-
   if (dataSourcesHtml) {
-    if (!priceCardHtml && contentParts.length) {
-      contentParts.push(spacerRow(24));
-    }
-    contentParts.push(dataSourcesHtml);
+    contentParts.push(`<tr data-email-section="data-sources"><td style="padding:0 32px 32px 32px;">${dataSourcesHtml}</td></tr>`);
   }
 
   const content = contentParts.filter(Boolean).join('\n');
-  const wrapperMarkup = buildOuterWrapper(content);
+  const wrapperMarkup = buildOuterWrapper(content, brand);
   const wrapper = document.createElement('div');
   wrapper.innerHTML = wrapperMarkup;
 
@@ -1023,7 +1133,7 @@ async function buildLegacyEmailExportHTML(proposal, warnings) {
     '<meta http-equiv="x-ua-compatible" content="ie=edge">',
     '<meta name="viewport" content="width=device-width, initial-scale=1">',
     '</head>',
-    `<body style="margin:0; padding:0; background-color:#FFFFFF; font-family:${esc(fontFamily)};">`,
+    `<body style="margin:0; padding:0; background-color:${esc(EMAIL_BODY_BACKGROUND)}; font-family:${esc(fontFamily)};">`,
     emailBody,
     '</body></html>'
   ].join('');
@@ -1076,13 +1186,17 @@ async function buildEmailExportHTML(proposal) {
 
   let html = null;
   try {
-    html = await buildPreviewMirroredEmailHTML(proposal, warnings);
+    html = await buildLegacyEmailExportHTML(proposal, warnings);
   } catch (error) {
-    warnings.push(`Preview export unavailable: ${error?.message || error}`);
+    warnings.push(`Enterprise email layout failed: ${error?.message || error}`);
   }
 
   if (!html) {
-    html = await buildLegacyEmailExportHTML(proposal, warnings);
+    try {
+      html = await buildPreviewMirroredEmailHTML(proposal, warnings);
+    } catch (error) {
+      warnings.push(`Preview export unavailable: ${error?.message || error}`);
+    }
   }
 
   if (!html) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -967,7 +967,7 @@ test('email export inlines HTTPS pictogram icons as data URIs', async () => {
   }
 });
 
-test('preview email export mirrors preview layout with inline images', async () => {
+test('email export builds enterprise layout with inline images', async () => {
   const { __private: emailExportPrivate } = require('../js/emailExport.js');
   const originalDocument = global.document;
   const originalWindow = global.window;
@@ -1045,7 +1045,9 @@ test('preview email export mirrors preview layout with inline images', async () 
     const result = await emailExportPrivate.buildEmailExportHTML(proposal);
 
     assert.ok(result.html.includes('Preview Headline'));
-    assert.ok(result.html.includes('id="preview-export"'));
+    assert.ok(result.html.includes('data-email-section="hero"'));
+    assert.ok(result.html.includes('data-email-card="executive-summary"'));
+    assert.ok(!result.html.includes('id="preview-export"'));
     assert.ok(result.html.includes('data:image/png;base64,stub-preview'));
     assert.deepEqual(fetchedUrls, ['https://cdn.example.com/banner.png']);
   } finally {


### PR DESCRIPTION
## Summary
- rebuild the HTML export builder to produce a table-driven layout with branded cards, pricing grid, and investment section that mirrors the preview styling without relying on flexbox
- inline enterprise layout metadata on sections/cards and update README to describe the dedicated email markup
- refresh regression tests to cover the new enterprise email export structure and preserve image inlining

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5aab7ee78832a8ae0b556d7c0af54