### PR TITLE
Remove duplicate clipRoundedRect helper definition

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1685,7 +1685,6 @@ function initializeApp() {
     }
   };
 
- codex/add-lower-corner-rounding-to-banner-images-x76337
   const normalizeCornerRadii = (radii, w, h) => {
     const maxRadius = Math.min(w, h) / 2;
     if (typeof radii === "number") {
@@ -1704,29 +1703,6 @@ function initializeApp() {
 
   const buildRoundedRectPath = (ctx, x, y, w, h, radii) => {
     const { tl, tr, br, bl } = normalizeCornerRadii(radii, w, h);
-
-  const clipRoundedRect = (ctx, x, y, w, h, radii) => {
-    const normalized = (() => {
-      if (typeof radii === "number") {
-        return { tl: radii, tr: radii, br: radii, bl: radii };
-      }
-      if (radii && typeof radii === "object") {
-        return {
-          tl: Math.max(0, radii.tl || 0),
-          tr: Math.max(0, radii.tr || 0),
-          br: Math.max(0, radii.br || 0),
-          bl: Math.max(0, radii.bl || 0),
-        };
-      }
-      return { tl: 0, tr: 0, br: 0, bl: 0 };
-    })();
-
-    const tl = Math.min(normalized.tl, Math.min(w, h) / 2);
-    const tr = Math.min(normalized.tr, Math.min(w, h) / 2);
-    const br = Math.min(normalized.br, Math.min(w, h) / 2);
-    const bl = Math.min(normalized.bl, Math.min(w, h) / 2);
- main
-
     ctx.beginPath();
     ctx.moveTo(x + tl, y);
     ctx.lineTo(x + w - tr, y);


### PR DESCRIPTION
## Summary
- remove the stray merge artifact that redefined clipRoundedRect in app.js
- ensure buildRoundedRectPath contains the path instructions for rounded rectangles

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b1391b14832aaf77c7d241a26cc2)